### PR TITLE
Заготовка для сетевых запросов (Retrofit)

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/data/dto/Response.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/dto/Response.kt
@@ -1,0 +1,13 @@
+package ru.practicum.android.diploma.data.dto
+
+open class Response {
+    var resultCode = OK
+
+    companion object {
+        const val NETWORK_CONNECTION_ERROR = -1
+        const val OK = 200
+        const val NETWORK_ERROR = 400
+        const val NETWORK_CONNECTION_RETRIES = 3
+        const val NETWORK_CONNECTION_DELAY = 500L
+    }
+}

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/HHApi.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/HHApi.kt
@@ -1,0 +1,5 @@
+package ru.practicum.android.diploma.data.network
+
+const val HHBASEURL = "https://api.hh.ru/"
+
+interface HHApi

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/NetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/NetworkClient.kt
@@ -1,0 +1,7 @@
+package ru.practicum.android.diploma.data.network
+
+import ru.practicum.android.diploma.data.dto.Response
+
+interface NetworkClient {
+    suspend fun doRequest(dto: Any): Response
+}

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/NetworkRequestException.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/NetworkRequestException.kt
@@ -1,0 +1,3 @@
+package ru.practicum.android.diploma.data.network
+
+class NetworkRequestException : Exception()

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
@@ -1,0 +1,53 @@
+package ru.practicum.android.diploma.data.network
+
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.util.Log
+import kotlinx.coroutines.delay
+import ru.practicum.android.diploma.data.dto.Response
+
+class RetrofitNetworkClient(
+    private val hhApi: HHApi,
+    private val connectivityManager: ConnectivityManager
+) : NetworkClient {
+
+    override suspend fun doRequest(dto: Any): Response {
+        val response = Response()
+        try {
+            if (!waitForConnection()) {
+                response.apply { resultCode = Response.NETWORK_CONNECTION_ERROR }
+            }
+            //
+            // Реализовать содержательные сетевые запросы
+            //
+            response.apply { resultCode = Response.OK }
+        } catch (ex: NetworkRequestException) {
+            Log.i("NetworkError", ex.message!!)
+            response.apply { resultCode = Response.NETWORK_ERROR }
+        }
+        return response
+    }
+
+    private fun isConnected(): Boolean {
+        var result = false
+        val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+        if (capabilities != null) {
+            when {
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> result = true
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> result = true
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> result = true
+            }
+        }
+        return result
+    }
+
+    private suspend fun waitForConnection(): Boolean {
+        repeat(Response.NETWORK_CONNECTION_RETRIES) {
+            if (isConnected()) {
+                return true
+            }
+            delay(Response.NETWORK_CONNECTION_DELAY)
+        }
+        return false
+    }
+}

--- a/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
@@ -1,5 +1,38 @@
 package ru.practicum.android.diploma.di
 
+import android.content.Context
+import com.google.gson.Gson
+import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import ru.practicum.android.diploma.data.network.HHApi
+import ru.practicum.android.diploma.data.network.HHBASEURL
+import ru.practicum.android.diploma.data.network.NetworkClient
+import ru.practicum.android.diploma.data.network.RetrofitNetworkClient
 
-val dataModule = module {}
+private const val MYCOOLOFFER_PREFERENCES = "mycooloffer_preferences"
+
+val dataModule = module {
+    single<HHApi> {
+        Retrofit.Builder()
+            .baseUrl(HHBASEURL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(HHApi::class.java)
+    }
+
+    single<NetworkClient> {
+        RetrofitNetworkClient(get(), get())
+    }
+
+    single { Gson() }
+
+    single {
+        androidContext().getSystemService(Context.CONNECTIVITY_SERVICE)
+    }
+
+    single {
+        androidContext().getSharedPreferences(MYCOOLOFFER_PREFERENCES, Context.MODE_PRIVATE)
+    }
+}


### PR DESCRIPTION
Заготовка для сетевых запросов (Retrofit)
1. Реализовал в DataModule DI для Retrofit, Gson и заодно для SharedPreferencies
2. Создал класс Response
3. Создал интерфейс NetworkClient
4. Создал пустой интерфейс HHApi
5. Создал пустой класс-наследник NetworkRequestException, чтобы не ругался detekt
6. Создал класс RetrofitNetworkClient